### PR TITLE
[WAYF-91] Fix Dockerfile/Swagger import

### DIFF
--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -32,6 +32,6 @@ RUN npm i
 # Copy compiled build from base
 COPY --from=base /usr/api/dist .
 # Copy swagger over too
-#COPY --from=base /usr/api/docs ./docs
+COPY --from=base /usr/api/public ./public
 
 CMD [ "node", "server.js" ]


### PR DESCRIPTION
# Description

It was observed that the deployment of the API was not serving the Swagger Documentation

This PR includes the following proposed change(s):

- One line from original dockerfile was uncommented and had its route modified. Pre-change this was resulting in the Swagger file not being imported in the Docker build.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Frontend Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing
