### PR TITLE
[WAYF-107] FEATURE** CSS Cleanup for Map / Service

### DIFF
--- a/src/frontend-pwa/src/components/Footer/footer.styles.ts
+++ b/src/frontend-pwa/src/components/Footer/footer.styles.ts
@@ -19,7 +19,7 @@ export const FooterWrapper = styled.footer`
   position: fixed;
   width: 100%;
   left: 0;
-  z-index: 2;
+  z-index: 2000;
 `;
 
 export const Container = styled.div`

--- a/src/frontend-pwa/src/components/Header/header.styles.ts
+++ b/src/frontend-pwa/src/components/Header/header.styles.ts
@@ -22,7 +22,7 @@ export const HeaderWrapper = styled.header`
         justify-content: space-evenly;
         padding: 0px;
     }
-    z-index: 2;
+    z-index: 2000;
 `;
 
 export const Heading = styled.h2`

--- a/src/frontend-pwa/src/components/ListItems/listitems.style.ts
+++ b/src/frontend-pwa/src/components/ListItems/listitems.style.ts
@@ -39,7 +39,6 @@ export const Container = styled.div`
   height: 300px;
   overflow: auto;
   width: 100%;
-  border-radius: 8pt;
   scrollbar-width: thin;
   scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
   &::-webkit-scrollbar {
@@ -51,5 +50,8 @@ export const Container = styled.div`
     background-color: rgba(0, 0, 0, 0.3);
     border-radius: 4px;
     background: none;
+  }
+  @media (min-width: 768px){
+      border-radius: 8pt;
   }
 `;

--- a/src/frontend-pwa/src/components/Mapping/Mapping.tsx
+++ b/src/frontend-pwa/src/components/Mapping/Mapping.tsx
@@ -68,7 +68,7 @@ export default function Mapping({ locations, currentLocation }: MappingProps) {
   const long = parseFloat(currentLocation?.long);
 
   return (
-    <div>
+    <MapWrapperDiv>
       { !isNaN(lat)
       && (
       <MapWrapperDiv>
@@ -114,6 +114,6 @@ export default function Mapping({ locations, currentLocation }: MappingProps) {
         </StyledMapContainer>
       </MapWrapperDiv>
       )}
-    </div>
+    </MapWrapperDiv>
   );
 }

--- a/src/frontend-pwa/src/components/Mapping/mapping.styles.ts
+++ b/src/frontend-pwa/src/components/Mapping/mapping.styles.ts
@@ -12,19 +12,22 @@ import {
 
 export const MapWrapperDiv = styled.div`
     ${typography.toString()}
-    width: 100%;
-    height: 100%;
 `;
 
 export const StyledMapContainer = styled(MapContainer)`
     ${typography.toString()}
     height: 39.5svh;
-    width: 95svw;
+    max-height: 70svh;
+    width: 100svw;
     overflow: hidden;
     @media (min-width: 768px) {
-        height: 65vh;
-        width: 40vw;
-      }
+        height: 500pt;
+        width: 350pt;
+    }
+    @media (min-width: 1000px) {
+        height: 500pt;
+        width: 500pt;
+    }
 `;
 
 export const StyledPopup = styled(Popup)`

--- a/src/frontend-pwa/src/views/BCServices/BCServices.tsx
+++ b/src/frontend-pwa/src/views/BCServices/BCServices.tsx
@@ -38,17 +38,20 @@ export default function BCServices() {
   return (
     <ViewContainer>
       <ContentContainer>
-        <MapContainer>
-          {navigator.onLine
-            ? (
-              <Mapping locations={filteredLocationSearch} currentLocation={currentLocation} />
-            )
-            : (
+        {navigator.onLine
+          ? (
+            <Mapping
+              locations={filteredLocationSearch}
+              currentLocation={currentLocation}
+            />
+          )
+          : (
+            <MapContainer>
               <StyledP>
                 Sorry this feature is currently unavailable offline.
               </StyledP>
-            )}
-        </MapContainer>
+            </MapContainer>
+          )}
         <ServiceListContainer>
           <SearchBar
             query={searchQuery}

--- a/src/frontend-pwa/src/views/BCServices/bcservices.styles.ts
+++ b/src/frontend-pwa/src/views/BCServices/bcservices.styles.ts
@@ -24,7 +24,8 @@ export const ContentContainer = styled.div`
   height: 100%;
   align-items: center;
   justify-content: center;
-  max-width: 1000px;
+  max-width: 1250px;
+  overflow: hidden;
   @media (min-width: 768px) {
     flex-direction: row-reverse;
     padding: inherit 10pt;
@@ -41,7 +42,8 @@ export const ServiceListContainer = styled.div`
   @media (min-width: 768px) {
     height: 100%;
     max-height: 100%;
-    margin-right: 1em;
+    width: 425pt;
+    margin: 0 1em;
   }
 `;
 
@@ -52,7 +54,6 @@ export const MapContainer = styled.div`
   width: 100%;
   align-items: center;
   justify-content: center;
-  background-color: #e8e8e8;
   @media (min-width: 768px) {
     height: 100%;
     border-radius: 4pt;


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[WAYF-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):
- Learned Leaflet uses arbitrary z-index values so greatly boosted the header and footer to accomodate that
- Modified BC Services Views CSS to account for the new mapping component (compared to previous static image)
- Removed `<MapContainer>` from wrapping Mapping in BC Services, only using it for filling in the Offline mode space
- added media queries with static values to help not overflow the screen in use.

Old: 
![image](https://github.com/bcgov/citz-imb-wayfinder/assets/62873746/db7bcc3b-4494-4878-b250-8321f4825127)

New:
![image](https://github.com/bcgov/citz-imb-wayfinder/assets/62873746/b04ce3b1-c7a4-4a41-a0e9-68ff62c207c1)

Old:
![image](https://github.com/bcgov/citz-imb-wayfinder/assets/62873746/07237e51-beac-400a-8904-7071967307f2)

New:
![image](https://github.com/bcgov/citz-imb-wayfinder/assets/62873746/4c436e50-2902-41ac-8bd1-a9c316ca11b7)
