### PR TITLE
[WAYF-191] Implement 404 Component

### DIFF
--- a/src/frontend-pwa/src/components/utility/Mapping/Mapping.tsx
+++ b/src/frontend-pwa/src/components/utility/Mapping/Mapping.tsx
@@ -68,7 +68,6 @@ const redIcon = Leaflet.icon({
 export default function Mapping({ locations, currentLocation }: MappingProps) {
   const lat = parseFloat(currentLocation?.lat);
   const long = parseFloat(currentLocation?.long);
-  const { service } = useParams();
   return (
     <MapWrapperDiv>
       { !isNaN(lat)

--- a/src/frontend-pwa/src/routes/ViewRouter.tsx
+++ b/src/frontend-pwa/src/routes/ViewRouter.tsx
@@ -13,6 +13,7 @@ import AboutContact from '../views/AboutContact/AboutContact';
 import Eula from '../views/Eula/Eula';
 import OfficeOptionsView from '../views/OfficeOptionsView/OfficeOptionsView';
 import LocationInformation from '../views/LocationInformation/LocationInformation';
+import NotFound from '../views/NotFound/NotFound';
 
 export default function ViewRouter() {
   return (
@@ -26,6 +27,7 @@ export default function ViewRouter() {
       <Route path="/settings/about" Component={AboutContact} />
       <Route path="/location" Component={OfficeOptionsView} />
       <Route path="/location/:service/:locale" Component={LocationInformation} />
+      <Route path="*" Component={NotFound} />
     </Routes>
   );
 }

--- a/src/frontend-pwa/src/views/LocationInformation/LocationInformation.tsx
+++ b/src/frontend-pwa/src/views/LocationInformation/LocationInformation.tsx
@@ -7,6 +7,7 @@
 import { Link, useParams } from 'react-router-dom';
 import useAppService from '../../services/app/useAppService';
 import { SingleLocation } from '../../Type';
+import NotFound from '../NotFound/NotFound';
 import {
   ContentContainer,
   Text,
@@ -21,10 +22,9 @@ import { ListItems, ServiceListItem } from '../../components/lists';
 export default function LocationInformation() {
   const { state } = useAppService();
   const { service, locale } = useParams();
-  const FourOhFour = <Text>404 Not Found</Text>;
   const locations = state.appData?.data ? state.appData.data[`${service}Locations`] : [];
   if (!locations) {
-    return FourOhFour;
+    return <NotFound />;
   }
   const location: SingleLocation = locations.filter(
     (element: SingleLocation) => element.locale === locale,
@@ -97,7 +97,7 @@ export default function LocationInformation() {
               )}
             </>
           )
-          : FourOhFour}
+          : <NotFound />}
       </ContentContainer>
     </ViewContainer>
   );

--- a/src/frontend-pwa/src/views/NotFound/NotFound.style.ts
+++ b/src/frontend-pwa/src/views/NotFound/NotFound.style.ts
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled';
+import mq from '../../constants/mq';
+
+export const ViewContainer = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  min-height: 100svh;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`;
+export const ContentContainer = styled.div`
+  display: flex;
+  padding: 55pt 10pt;
+  flex-direction: column;
+  height: 100%;
+  align-items: center;
+  justify-content: left;
+  max-width: 300pt;
+  overflow: hidden;
+  @media (min-width: ${mq.tablet}) {
+    padding: inherit 10pt;
+  }
+`;
+export const Bold = styled.span`
+  font-weight: 700;
+`;
+export const Soft = styled.span`
+  color: #777;
+`;
+export const Text = styled.p`
+  
+`;
+export const HeaderTwo = styled.h2`
+
+`;
+export const TextContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  align-items: center;
+  justify-content: left;
+`;

--- a/src/frontend-pwa/src/views/NotFound/NotFound.style.ts
+++ b/src/frontend-pwa/src/views/NotFound/NotFound.style.ts
@@ -1,3 +1,7 @@
+/**
+ * @summary Styling for NotFound component
+ * @author LocalNewsTV
+ */
 import styled from '@emotion/styled';
 import mq from '../../constants/mq';
 

--- a/src/frontend-pwa/src/views/NotFound/NotFound.tsx
+++ b/src/frontend-pwa/src/views/NotFound/NotFound.tsx
@@ -1,3 +1,7 @@
+/**
+ * @summary 404 Page that returns to home, and references the url provided in its error message
+ * @author LocalNewsTV
+ */
 import { Link, useLocation } from 'react-router-dom';
 import { Button } from '../../components/common';
 import {

--- a/src/frontend-pwa/src/views/NotFound/NotFound.tsx
+++ b/src/frontend-pwa/src/views/NotFound/NotFound.tsx
@@ -1,0 +1,52 @@
+import { Link, useLocation } from 'react-router-dom';
+import { Button } from '../../components/common';
+import {
+  Bold,
+  ContentContainer,
+  HeaderTwo,
+  Soft,
+  Text,
+  TextContainer,
+  ViewContainer,
+} from './NotFound.style';
+
+function NotFound() {
+  const route = useLocation();
+  return (
+    <ViewContainer>
+      <ContentContainer>
+        <TextContainer>
+          <HeaderTwo>
+            Not Found
+          </HeaderTwo>
+        </TextContainer>
+        <TextContainer>
+          <Text>
+            <Bold>404.&nbsp;</Bold>
+            <Soft>That&apos;s an error</Soft>
+          </Text>
+        </TextContainer>
+        <TextContainer>
+          <Text>
+            {`The requested URL\u00a0\u00a0${route.pathname} was not found on this server.`}
+            <Soft>
+              &nbsp;That&apos;s all we know
+            </Soft>
+          </Text>
+        </TextContainer>
+        <TextContainer>
+          <Link to="/">
+            <Button
+              text="Go Home"
+              size="sm"
+              variant="primary"
+              disabled={false}
+            />
+          </Link>
+        </TextContainer>
+      </ContentContainer>
+    </ViewContainer>
+  );
+}
+
+export default NotFound;


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[WAYF-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Made a 404 View loosely modelled off the one used by Google (but without the neato robot)

![image](https://github.com/bcgov/citz-imb-wayfinder/assets/62873746/260bc7d9-ba46-493f-a34b-a2e9612bffe8)

Mobile Google one
![image](https://github.com/bcgov/citz-imb-wayfinder/assets/62873746/4b161697-7781-493e-bf3e-c8ae47462fa7)

Desktop Google one (avec Roboto)
![image](https://github.com/bcgov/citz-imb-wayfinder/assets/62873746/bf166fc9-edf5-4f15-9723-a9ed5d58e48c)


