### PR TITLE
[WAYF-183] FEATURE** Caching Analytics Offline

### DIFF
--- a/src/frontend-pwa/src/constants/Constants.ts
+++ b/src/frontend-pwa/src/constants/Constants.ts
@@ -5,6 +5,7 @@ const constants = {
   CURRENT_LOCATION_KEY: 'currentLocation',
   EULA_ACCEPTED_KEY: 'eulaAccepted',
   SETTINGS_KEY: 'settings',
+  OFFLINE_ANALYTIC_KEY: 'analyticsOffline',
 };
 
 export default constants;

--- a/src/frontend-pwa/src/services/app/useAppService.ts
+++ b/src/frontend-pwa/src/services/app/useAppService.ts
@@ -6,6 +6,8 @@ import constants from '../../constants/Constants';
 import AppActionType from './AppActions';
 import { saveDataToLocalStorage, getDataFromLocalStorage, localStorageKeyExists } from '../../utils/AppLocalStorage';
 import SettingsObject from '../../Type/SettingsObject';
+import Analytic from '../../Type/Analytic';
+import SendAnalytics from '../../utils/SendAnalytics';
 
 const {
   SET_APP_DATA,
@@ -177,6 +179,26 @@ const useAppService = () => {
       dispatch({ type: SET_SETTINGS, payload: settings });
     };
 
+    /**
+     * @summary Send analytic data to database if online, else stores n localstorage
+     * @param analytics is an analytic object containing location and usage data
+     * @type {( Analytic )}
+     * @author Dallas Richmond
+     */
+    // TODO Add a check if analytic data is a report. If so, save as report data
+    // and add to state
+    const setAnalytics = (online: boolean, analytics: Analytic) => {
+      if (online) {
+        SendAnalytics(analytics);
+      } else if (localStorageKeyExists(constants.OFFLINE_ANALYTIC_KEY)) {
+        const data = getDataFromLocalStorage(constants.OFFLINE_ANALYTIC_KEY);
+        data.push(analytics);
+        saveDataToLocalStorage(constants.OFFLINE_ANALYTIC_KEY, data);
+      } else {
+        saveDataToLocalStorage(constants.OFFLINE_ANALYTIC_KEY, [analytics]);
+      }
+    };
+
     return {
       setAppData,
       setCurrentLocation,
@@ -185,6 +207,7 @@ const useAppService = () => {
       setEulaState,
       updateSettings,
       setSettings,
+      setAnalytics,
       state,
     };
   }, [state, dispatch]);

--- a/src/frontend-pwa/src/services/app/useAppService.ts
+++ b/src/frontend-pwa/src/services/app/useAppService.ts
@@ -180,8 +180,8 @@ const useAppService = () => {
     };
 
     /**
-     * @summary Send analytic data to database if online, else stores n localstorage
-     * @param analytics is an analytic object containing location and usage data
+     * @summary Sends analytic data to database if online, else stores in localstorage
+     * @param analytics is an object containing location and usage data
      * @type {( Analytic )}
      * @author Dallas Richmond
      */

--- a/src/frontend-pwa/src/utils/SendAnalytics.ts
+++ b/src/frontend-pwa/src/utils/SendAnalytics.ts
@@ -9,7 +9,8 @@ import axios from 'axios';
 import constants from '../constants/Constants';
 import Analytic from '../Type/Analytic';
 
-const Analytics = (request: Analytic) => {
+// TODO remove console.logs
+const SendAnalytics = (request: Analytic) => {
   axios.post(`${constants.BACKEND_URL}/api/analytic`, request)
     .then((data) => {
       console.log('Data: ', data);
@@ -19,4 +20,4 @@ const Analytics = (request: Analytic) => {
     });
 };
 
-export default Analytics;
+export default SendAnalytics;

--- a/src/frontend-pwa/src/views/Location/Location.tsx
+++ b/src/frontend-pwa/src/views/Location/Location.tsx
@@ -5,6 +5,7 @@
  *                  -Sorts all available locations by distance
  *                  -Only displays locations in range of user settings
  *                  -Users can filter by location search
+ *                  -Analytics sent or cached if offline
  * @param locations an array of single locations pulled from the /location endpoint
  * @type {(locations : Array<SingleLocation>)}
  * @author Dallas Richmond, LocalNewsTV

--- a/src/frontend-pwa/src/views/LocationInformation/LocationInformation.tsx
+++ b/src/frontend-pwa/src/views/LocationInformation/LocationInformation.tsx
@@ -3,6 +3,8 @@
  *          Conditional renders set per item to account for variants in SingleLocation items
  *          Page loads passed on url params then filters the data set
  *          Page displays 404 if invalid query sent
+ *          Analytics sent or cached if offline
+ * @author LocalNewsTV, Dallas Richmond
  */
 import { Link, useParams } from 'react-router-dom';
 import useAppService from '../../services/app/useAppService';

--- a/src/frontend-pwa/src/views/LocationInformation/LocationInformation.tsx
+++ b/src/frontend-pwa/src/views/LocationInformation/LocationInformation.tsx
@@ -18,17 +18,44 @@ import {
   Address,
 } from './locationInformation.style';
 import { ListItems, ServiceListItem } from '../../components/lists';
+import OnlineCheck from '../../utils/OnlineCheck';
+import { localStorageKeyExists } from '../../utils/AppLocalStorage';
+import constants from '../../constants/Constants';
 
 export default function LocationInformation() {
-  const { state } = useAppService();
+  const { state, setAnalytics } = useAppService();
   const { service, locale } = useParams();
   const locations = state.appData?.data ? state.appData.data[`${service}Locations`] : [];
+  const geolocationKnown = localStorageKeyExists(constants.CURRENT_LOCATION_KEY);
   if (!locations) {
     return <NotFound />;
   }
   const location: SingleLocation = locations.filter(
     (element: SingleLocation) => element.locale === locale,
   )[0];
+
+  // Potentially wrap in useEffect
+  if (geolocationKnown) {
+    const latitude = state.currentLocation.lat;
+    const longitude = state.currentLocation.long;
+    const analytics = {
+      latitude,
+      longitude,
+      usage: {
+        search: location.locale,
+        function: 'find location',
+      },
+    };
+
+    if (state.settings.offline_mode) {
+      setAnalytics(false, analytics);
+    } else {
+      OnlineCheck()
+        .then((Online) => {
+          setAnalytics(Online, analytics);
+        });
+    }
+  }
 
   return (
     <ViewContainer>

--- a/src/frontend-pwa/src/views/LocationInformation/LocationInformation.tsx
+++ b/src/frontend-pwa/src/views/LocationInformation/LocationInformation.tsx
@@ -34,7 +34,6 @@ export default function LocationInformation() {
     (element: SingleLocation) => element.locale === locale,
   )[0];
 
-  // Potentially wrap in useEffect
   if (geolocationKnown) {
     const latitude = state.currentLocation.lat;
     const longitude = state.currentLocation.long;

--- a/src/frontend-pwa/src/views/Report/Report.tsx
+++ b/src/frontend-pwa/src/views/Report/Report.tsx
@@ -118,7 +118,6 @@ export default function Report() {
       time: currentTime,
     };
 
-    // Potentially wrap in useEffect
     if (geolocationKnown) {
       const analytics = {
         latitude,


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[WAYF-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- Added setAnalytics to useAppService that sends data to database if online, or stores data in local storage to be sent when next online (next ticket will deal with that)
- Both LocationInformation and Report views have been updated to check if the offline user setting is enabled, if so it calls setAnalytics to cache the data. If not enabled, an online check is made to ensure the device is online and will determine what to do from there depending on the response from the online check
- Comments added/updated
