### PR TITLE
[WAYF-227] FEATURE** Report Error Handling

### DIFF
--- a/src/frontend-pwa/src/components/utility/SplashScreen/SplashScreen.tsx
+++ b/src/frontend-pwa/src/components/utility/SplashScreen/SplashScreen.tsx
@@ -10,6 +10,7 @@ import { Spinner } from '../../common';
 import useAppService from '../../../services/app/useAppService';
 import OnlineCheck from '../../../utils/OnlineCheck';
 import { SendCachedAnalytics } from '../../../utils/AppAnalytics';
+import { SendCachedReports } from '../../../utils/AppReports';
 import {
   SplashScreenWrapper,
   Image,
@@ -50,6 +51,7 @@ export default function SplashScreen() {
         .then((Online) => {
           setAppData(Online);
           SendCachedAnalytics(Online);
+          SendCachedReports(Online);
         }).catch((error) => {
           console.error('Error: ', error);
         });

--- a/src/frontend-pwa/src/components/utility/SplashScreen/SplashScreen.tsx
+++ b/src/frontend-pwa/src/components/utility/SplashScreen/SplashScreen.tsx
@@ -23,6 +23,7 @@ export default function SplashScreen() {
     setAppData,
     initializeEulaState,
     updateSettings,
+    setSuccessfulReports,
     state,
   } = useAppService();
 
@@ -51,7 +52,7 @@ export default function SplashScreen() {
         .then((Online) => {
           setAppData(Online);
           SendCachedAnalytics(Online);
-          SendCachedReports(Online);
+          SendCachedReports(Online, setSuccessfulReports);
         }).catch((error) => {
           console.error('Error: ', error);
         });

--- a/src/frontend-pwa/src/constants/Constants.ts
+++ b/src/frontend-pwa/src/constants/Constants.ts
@@ -7,6 +7,7 @@ const constants = {
   SETTINGS_KEY: 'settings',
   OFFLINE_ANALYTIC_KEY: 'analyticsOffline',
   REPORTS_KEY: 'reports',
+  UNSENT_REPORTS_KEY: 'unsentReports',
 };
 
 export default constants;

--- a/src/frontend-pwa/src/content/content.ts
+++ b/src/frontend-pwa/src/content/content.ts
@@ -265,8 +265,8 @@ export const reportContent: ContentMap = {
     fr: 'Impossible de soumettre le rapport.',
   },
   reportNetworkFailure: {
-    eng: 'Unable to submit report. The report is saved and will be sent when the device is back online.',
-    fr: 'Impossible de soumettre le rapport. Le rapport est enregistré et sera envoyé lorsque l\'appareil sera de nouveau en ligne.',
+    eng: 'Offline: The report is saved and will be sent when the device is back online.',
+    fr: 'Hors ligne: Le rapport est enregistré et sera envoyé lorsque l\'appareil sera de nouveau en ligne.',
   },
   detailsLabel: {
     eng: 'Event details:',

--- a/src/frontend-pwa/src/content/content.ts
+++ b/src/frontend-pwa/src/content/content.ts
@@ -264,6 +264,10 @@ export const reportContent: ContentMap = {
     eng: 'Unable to submit report.',
     fr: 'Impossible de soumettre le rapport.',
   },
+  reportNetworkFailure: {
+    eng: 'Unable to submit report. The report is saved and will be sent when the device is back online.',
+    fr: 'Impossible de soumettre le rapport. Le rapport est enregistré et sera envoyé lorsque l\'appareil sera de nouveau en ligne.',
+  },
   detailsLabel: {
     eng: 'Event details:',
     fr: 'Détails de l\'événement :',

--- a/src/frontend-pwa/src/content/content.ts
+++ b/src/frontend-pwa/src/content/content.ts
@@ -265,8 +265,8 @@ export const reportContent: ContentMap = {
     fr: 'Impossible de soumettre le rapport.',
   },
   reportNetworkFailure: {
-    eng: 'Offline: The report is saved and will be sent when the device is back online.',
-    fr: 'Hors ligne: Le rapport est enregistré et sera envoyé lorsque l\'appareil sera de nouveau en ligne.',
+    eng: 'Offline: Report saved for future online submission.',
+    fr: 'Hors ligne : rapport enregistré pour une future soumission en ligne.',
   },
   detailsLabel: {
     eng: 'Event details:',

--- a/src/frontend-pwa/src/services/app/useAppService.ts
+++ b/src/frontend-pwa/src/services/app/useAppService.ts
@@ -211,7 +211,7 @@ const useAppService = () => {
      * @type    {( report: Report )}
      * @author  Dallas Richmond
      */
-    const setReports = (report: Report) => {
+    const setSuccessfulReports = (report: Report) => {
       if (localStorageKeyExists(constants.REPORTS_KEY)) {
         const data = getDataFromLocalStorage(constants.REPORTS_KEY);
         data.push(report);
@@ -220,6 +220,22 @@ const useAppService = () => {
         saveDataToLocalStorage(constants.REPORTS_KEY, [report]);
       }
       dispatch({ type: SET_REPORTS, payload: getDataFromLocalStorage(constants.REPORTS_KEY) });
+    };
+
+    /**
+     * @summary Saves unsuccessful reports to local storage
+     * @param   report is a report to be saved to local storage
+     * @type    {( report: Report )}
+     * @author  Dallas Richmond
+     */
+    const setOfflineReports = (report: Report) => {
+      if (localStorageKeyExists(constants.UNSENT_REPORTS_KEY)) {
+        const data = getDataFromLocalStorage(constants.UNSENT_REPORTS_KEY);
+        data.push(report);
+        saveDataToLocalStorage(constants.UNSENT_REPORTS_KEY, data);
+      } else {
+        saveDataToLocalStorage(constants.UNSENT_REPORTS_KEY, [report]);
+      }
     };
 
     /**
@@ -241,8 +257,9 @@ const useAppService = () => {
       updateSettings,
       setSettings,
       setAnalytics,
-      setReports,
+      setSuccessfulReports,
       setToolTipText,
+      setOfflineReports,
       state,
     };
   }, [state, dispatch]);

--- a/src/frontend-pwa/src/services/app/useAppService.ts
+++ b/src/frontend-pwa/src/services/app/useAppService.ts
@@ -224,7 +224,7 @@ const useAppService = () => {
 
     /**
      * @summary Saves unsuccessful reports to local storage
-     * @param   report is a user event to be saved to local storage
+     * @param   report is a user submitted Report object to be saved to local storage
      * @type    {( report: Report )}
      * @author  Dallas Richmond
      */

--- a/src/frontend-pwa/src/services/app/useAppService.ts
+++ b/src/frontend-pwa/src/services/app/useAppService.ts
@@ -224,7 +224,7 @@ const useAppService = () => {
 
     /**
      * @summary Saves unsuccessful reports to local storage
-     * @param   report is a report to be saved to local storage
+     * @param   report is a user event to be saved to local storage
      * @type    {( report: Report )}
      * @author  Dallas Richmond
      */

--- a/src/frontend-pwa/src/utils/AppAnalytics.ts
+++ b/src/frontend-pwa/src/utils/AppAnalytics.ts
@@ -20,7 +20,6 @@ export const SendAnalytics = (request: Analytic) => {
  * @type    {( online: boolean )}
  * @author  Dallas Richmond
  */
-
 export const SendCachedAnalytics = (online: boolean) => {
   if (online && localStorageKeyExists(constants.OFFLINE_ANALYTIC_KEY)) {
     const data = getDataFromLocalStorage(constants.OFFLINE_ANALYTIC_KEY);

--- a/src/frontend-pwa/src/utils/AppReports.ts
+++ b/src/frontend-pwa/src/utils/AppReports.ts
@@ -3,7 +3,6 @@ import axios from 'axios';
 import Report from '../Type/Report';
 import constants from '../constants/Constants';
 import { localStorageKeyExists, getDataFromLocalStorage, deleteLocalStorageKey } from './AppLocalStorage';
-import useAppService from '../services/app/useAppService';
 
 /**
  * @summary Function that posts the request to the report endpoint
@@ -11,9 +10,7 @@ import useAppService from '../services/app/useAppService';
  * @type    {( request: Report )}
  * @author  Dallas Richmond
  */
-export const SendReport = async (request: Report) => {
-  const { setSuccessfulReports } = useAppService();
-
+export const SendReport = async (request: Report, setSuccessfulReports: Function) => {
   await axios.post(`${constants.BACKEND_URL}/api/report`, request)
     .then((res) => {
       setSuccessfulReports(res.data);
@@ -27,14 +24,15 @@ export const SendReport = async (request: Report) => {
  * @summary Checks to see if there are cached reports in local storage.
  *          If so, they are sent and the key is deleted
  * @param   online is a boolean value that indicates that the device is online
- * @type    {( online: boolean )}
+ * @param   setSuccessfulReports is a function from the useAppService hook
+ * @type    {( online: boolean, setSuccessfulReports: Function )}
  * @author  Dallas Richmond
  */
-export const SendCachedReports = (online: boolean) => {
+export const SendCachedReports = (online: boolean, setSuccessfulReports: Function) => {
   if (online && localStorageKeyExists(constants.UNSENT_REPORTS_KEY)) {
     const data = getDataFromLocalStorage(constants.UNSENT_REPORTS_KEY);
     data.forEach((report: Report) => {
-      SendReport(report);
+      SendReport(report, setSuccessfulReports);
     });
     deleteLocalStorageKey(constants.UNSENT_REPORTS_KEY);
   }

--- a/src/frontend-pwa/src/utils/AppReports.ts
+++ b/src/frontend-pwa/src/utils/AppReports.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+import axios from 'axios';
+import Report from '../Type/Report';
+import constants from '../constants/Constants';
+import { localStorageKeyExists, getDataFromLocalStorage, deleteLocalStorageKey } from './AppLocalStorage';
+import useAppService from '../services/app/useAppService';
+
+/**
+ * @summary Function that posts the request to the report endpoint
+ * @param   request is a report to be sent to the report endpoint
+ * @type    {( request: Report )}
+ * @author  Dallas Richmond
+ */
+export const SendReport = async (request: Report) => {
+  const { setSuccessfulReports } = useAppService();
+
+  await axios.post(`${constants.BACKEND_URL}/api/report`, request)
+    .then((res) => {
+      setSuccessfulReports(res.data);
+    })
+    .catch((err) => {
+      console.log(err);
+    });
+};
+
+/**
+ * @summary Checks to see if there are cached reports in local storage.
+ *          If so, they are sent and the key is deleted
+ * @param   online is a boolean value that indicates that the device is online
+ * @type    {( online: boolean )}
+ * @author  Dallas Richmond
+ */
+export const SendCachedReports = (online: boolean) => {
+  if (online && localStorageKeyExists(constants.UNSENT_REPORTS_KEY)) {
+    const data = getDataFromLocalStorage(constants.UNSENT_REPORTS_KEY);
+    data.forEach((report: Report) => {
+      SendReport(report);
+    });
+    deleteLocalStorageKey(constants.UNSENT_REPORTS_KEY);
+  }
+};

--- a/src/frontend-pwa/src/utils/AppReports.ts
+++ b/src/frontend-pwa/src/utils/AppReports.ts
@@ -7,6 +7,8 @@ import { localStorageKeyExists, getDataFromLocalStorage, deleteLocalStorageKey }
 /**
  * @summary Function that posts the request to the report endpoint
  * @param   request is a report to be sent to the report endpoint
+ * @param   setSuccessfulReports is a function from the useAppService hook
+ *          that saves successful reports to local storage
  * @type    {( request: Report )}
  * @author  Dallas Richmond
  */
@@ -25,6 +27,7 @@ export const SendReport = async (request: Report, setSuccessfulReports: Function
  *          If so, they are sent and the key is deleted
  * @param   online is a boolean value that indicates that the device is online
  * @param   setSuccessfulReports is a function from the useAppService hook
+ *          that saves successful reports to local storage
  * @type    {( online: boolean, setSuccessfulReports: Function )}
  * @author  Dallas Richmond
  */

--- a/src/frontend-pwa/src/views/Report/Report.tsx
+++ b/src/frontend-pwa/src/views/Report/Report.tsx
@@ -155,8 +155,12 @@ export default function Report() {
         // eslint-disable-next-line no-console
         console.log(err);
         setReportSentSuccess(false);
-        setErrorMessage(reportContent.reportFailure[lang]);
-        if (err.code === 'ERR_NETWORK') setOfflineReports(formData);
+        if (err.code === 'ERR_NETWORK') {
+          setOfflineReports(formData);
+          setErrorMessage(reportContent.reportNetworkFailure[lang]);
+        } else {
+          setErrorMessage(reportContent.reportFailure[lang]);
+        }
       });
   };
 

--- a/src/frontend-pwa/src/views/Report/Report.tsx
+++ b/src/frontend-pwa/src/views/Report/Report.tsx
@@ -154,6 +154,7 @@ export default function Report() {
     if (state.settings.offline_mode) {
       setOfflineReports(formData);
       setErrorMessage(reportContent.reportNetworkFailure[lang]);
+      setReportSending(true);
     } else {
       await axios.post(`${constants.BACKEND_URL}/api/report`, formData)
         .then((res) => {
@@ -173,6 +174,7 @@ export default function Report() {
           }
         });
     }
+    setReportSending(false);
   };
 
   useEffect(() => {

--- a/src/frontend-pwa/src/views/Report/Report.tsx
+++ b/src/frontend-pwa/src/views/Report/Report.tsx
@@ -40,16 +40,21 @@ export default function Report() {
   const [isFormValid, setIsFormValid] = useState(false);
   const [reportSentSuccess, setReportSentSuccess] = useState(false);
   const [ticketNum, setTicketNum] = useState(null);
-  const { state, setAnalytics, setReports } = useAppService();
+  const {
+    state,
+    setAnalytics,
+    setSuccessfulReports,
+    setOfflineReports,
+  } = useAppService();
   const { lang } = state.settings;
   const geolocationKnown = localStorageKeyExists(constants.CURRENT_LOCATION_KEY);
   const latitude = state.currentLocation ? state.currentLocation.lat : 49.2827;
   const longitude = state.currentLocation ? state.currentLocation.long : -123.2;
 
   /**
- * @desc - Validates the phone number (if inputted) against regex pattern.
- * @returns {boolean} Valid phone number format, or blank.
- */
+   * @desc - Validates the phone number (if inputted) against regex pattern.
+   * @returns {boolean} Valid phone number format, or blank.
+   */
   const validatePhoneNumber = useCallback((): boolean => {
     const regex = /^(?:\+?1-?)?(?:\(\d{3}\)|\d{3})-?\d{3}-?\d{4}$/gi;
     if (!phoneNumber || phoneNumber.match(regex)) {
@@ -61,10 +66,10 @@ export default function Report() {
   }, [phoneNumber, lang]);
 
   /**
- * @desc - Validates the detail input is longer than the minumum length, or not present.
- * @returns {boolean} - Indicates whether the message inputted is over the
- *                      character minimum, but under the maximum.
- */
+   * @desc - Validates the detail input is longer than the minumum length, or not present.
+   * @returns {boolean} - Indicates whether the message inputted is over the
+   *                      character minimum, but under the maximum.
+   */
   const validateDetailBox = useCallback((): boolean => {
     if (details.length >= minCharLimit && details.length <= charLimit) {
       return true;
@@ -75,11 +80,11 @@ export default function Report() {
   }, [details, charLimit, lang]);
 
   /**
- * @desc - Validates all form fields to ensure they contain valid values.
- * @param {boolean} isValid - Indicates whether the form fields are valid (true)
- *                            or not valid (false).
- * @returns {boolean}       - Returns isValid, set to either true or false.
- */
+   * @desc - Validates all form fields to ensure they contain valid values.
+   * @param {boolean} isValid - Indicates whether the form fields are valid (true)
+   *                            or not valid (false).
+   * @returns {boolean}       - Returns isValid, set to either true or false.
+   */
   const checkFormValidity = useCallback(() => {
     const isEventTypeValid = !!eventType;
     const isValid = isEventTypeValid && validateDetailBox() && validatePhoneNumber();
@@ -101,9 +106,9 @@ export default function Report() {
   };
 
   /**
- * @desc - Sends a "formData" object to the /report endpoint.
- *       - Form validity is determined externally through the useEffect below.
- */
+   * @desc - Sends a "formData" object to the /report endpoint.
+   *       - Form validity is determined externally through the useEffect below.
+   */
   const handleSubmit = async (e: { preventDefault: () => void }) => {
     e.preventDefault();
 
@@ -143,7 +148,7 @@ export default function Report() {
         setDetails('');
         setPhoneNumber('');
         setReportSentSuccess(true);
-        setReports(res.data);
+        setSuccessfulReports(res.data);
         setTicketNum(res.data.ticketNum);
       })
       .catch((err) => {
@@ -151,6 +156,7 @@ export default function Report() {
         console.log(err);
         setReportSentSuccess(false);
         setErrorMessage(reportContent.reportFailure[lang]);
+        if (err.code === 'ERR_NETWORK') setOfflineReports(formData);
       });
   };
 

--- a/src/frontend-pwa/src/views/Report/Report.tsx
+++ b/src/frontend-pwa/src/views/Report/Report.tsx
@@ -38,6 +38,7 @@ export default function Report() {
   const [phoneNumber, setPhoneNumber] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [isFormValid, setIsFormValid] = useState(false);
+  const [reportSending, setReportSending] = useState(false);
   const [reportSentSuccess, setReportSentSuccess] = useState(false);
   const [ticketNum, setTicketNum] = useState(null);
   const {
@@ -105,6 +106,13 @@ export default function Report() {
     setPhoneNumber(e.target.value);
   };
 
+  const clearFields = () => {
+    setErrorMessage('');
+    setEventType('');
+    setDetails('');
+    setPhoneNumber('');
+  };
+
   /**
    * @desc - Sends a "formData" object to the /report endpoint.
    *       - Form validity is determined externally through the useEffect below.
@@ -121,6 +129,8 @@ export default function Report() {
       phoneNumber,
       time: currentTime,
     };
+
+    clearFields();
 
     if (state.settings.analytics_opt_in && geolocationKnown) {
       const analytics = {
@@ -147,19 +157,17 @@ export default function Report() {
     } else {
       await axios.post(`${constants.BACKEND_URL}/api/report`, formData)
         .then((res) => {
-          setErrorMessage('');
-          setEventType('');
-          setDetails('');
-          setPhoneNumber('');
           setReportSentSuccess(true);
           setSuccessfulReports(res.data);
           setTicketNum(res.data.ticketNum);
+          setReportSending(true);
         })
         .catch((err) => {
           setReportSentSuccess(false);
           if (err.code === 'ERR_NETWORK') {
             setOfflineReports(formData);
             setErrorMessage(reportContent.reportNetworkFailure[lang]);
+            setReportSending(true);
           } else {
             setErrorMessage(reportContent.reportFailure[lang]);
           }
@@ -242,7 +250,7 @@ export default function Report() {
               text={reportContent.submit[lang]}
               variant="primary"
               size="md"
-              disabled={!isFormValid}
+              disabled={!reportSending && !isFormValid}
             />
           </ButtonSection>
         </StyledReportContainer>

--- a/src/frontend-pwa/src/views/Report/Report.tsx
+++ b/src/frontend-pwa/src/views/Report/Report.tsx
@@ -141,25 +141,30 @@ export default function Report() {
       }
     }
 
-    await axios.post(`${constants.BACKEND_URL}/api/report`, formData)
-      .then((res) => {
-        setErrorMessage('');
-        setEventType('');
-        setDetails('');
-        setPhoneNumber('');
-        setReportSentSuccess(true);
-        setSuccessfulReports(res.data);
-        setTicketNum(res.data.ticketNum);
-      })
-      .catch((err) => {
-        setReportSentSuccess(false);
-        if (err.code === 'ERR_NETWORK') {
-          setOfflineReports(formData);
-          setErrorMessage(reportContent.reportNetworkFailure[lang]);
-        } else {
-          setErrorMessage(reportContent.reportFailure[lang]);
-        }
-      });
+    if (state.settings.offline_mode) {
+      setOfflineReports(formData);
+      setErrorMessage(reportContent.reportNetworkFailure[lang]);
+    } else {
+      await axios.post(`${constants.BACKEND_URL}/api/report`, formData)
+        .then((res) => {
+          setErrorMessage('');
+          setEventType('');
+          setDetails('');
+          setPhoneNumber('');
+          setReportSentSuccess(true);
+          setSuccessfulReports(res.data);
+          setTicketNum(res.data.ticketNum);
+        })
+        .catch((err) => {
+          setReportSentSuccess(false);
+          if (err.code === 'ERR_NETWORK') {
+            setOfflineReports(formData);
+            setErrorMessage(reportContent.reportNetworkFailure[lang]);
+          } else {
+            setErrorMessage(reportContent.reportFailure[lang]);
+          }
+        });
+    }
   };
 
   useEffect(() => {

--- a/src/frontend-pwa/src/views/Report/Report.tsx
+++ b/src/frontend-pwa/src/views/Report/Report.tsx
@@ -152,8 +152,6 @@ export default function Report() {
         setTicketNum(res.data.ticketNum);
       })
       .catch((err) => {
-        // eslint-disable-next-line no-console
-        console.log(err);
         setReportSentSuccess(false);
         if (err.code === 'ERR_NETWORK') {
           setOfflineReports(formData);

--- a/src/frontend-pwa/src/views/Settings/Settings.tsx
+++ b/src/frontend-pwa/src/views/Settings/Settings.tsx
@@ -89,7 +89,7 @@ export default function Settings() {
               tip={SettingsContent.languageToolTip[lang]}
             />
           </TitleWrapper>
-          <StyledSelect onChange={handleLang} defaultValue={lang}>
+          <StyledSelect onChange={handleLang} value={lang} defaultValue={lang}>
             {SettingsContent.languages[lang].map((data: string, index: number) => (
             <option value={SettingsContent.languages.keys[index]} key={data}>{data}</option>
             ))}


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[WAYF-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

-If the Report post fails, and the reason for it's failure is 'NETWORK_ERR' then the report is saved in local storage (also if in online mode)
-If the Report fail for any other reason then the user simply gets an error message stating that the report could not be sent
-During the splashscreen, if back online the report are then sent again and added to report history in local storage
-Small bug fix in Settings view
-Documentation added
